### PR TITLE
Fixing memory leak fetching Enum vals each loop

### DIFF
--- a/rlImGui/rlImGui.cs
+++ b/rlImGui/rlImGui.cs
@@ -27,6 +27,7 @@ namespace rlImGui_cs
 
         private static ImGuiMouseCursor CurrentMouseCursor = ImGuiMouseCursor.COUNT;
         private static Dictionary<ImGuiMouseCursor, MouseCursor> MouseCursorMap;
+        private static KeyboardKey[] _keys;
 
         private static Texture2D FontTexture;
 
@@ -35,6 +36,8 @@ namespace rlImGui_cs
             MouseCursorMap = new Dictionary<ImGuiMouseCursor, MouseCursor>();
 
             FontTexture.id = 0;
+
+            _keys = (KeyboardKey[])Enum.GetValues(typeof(KeyboardKey));
 
             BeginInitImGui();
 
@@ -184,8 +187,7 @@ namespace rlImGui_cs
         {
             ImGuiIOPtr io = ImGui.GetIO();
 
-            foreach (KeyboardKey key in Enum.GetValues(typeof(KeyboardKey)))
-            {
+            foreach (var key in _keys) {
                 io.KeysDown[(int)key] = Raylib.IsKeyDown(key);
             }
 

--- a/rlImGui/rlImGui.cs
+++ b/rlImGui/rlImGui.cs
@@ -27,7 +27,7 @@ namespace rlImGui_cs
 
         private static ImGuiMouseCursor CurrentMouseCursor = ImGuiMouseCursor.COUNT;
         private static Dictionary<ImGuiMouseCursor, MouseCursor> MouseCursorMap;
-        private static KeyboardKey[] _keys;
+        private static KeyboardKey[] Keys;
 
         private static Texture2D FontTexture;
 
@@ -37,7 +37,7 @@ namespace rlImGui_cs
 
             FontTexture.id = 0;
 
-            _keys = (KeyboardKey[])Enum.GetValues(typeof(KeyboardKey));
+            Keys = (KeyboardKey[])Enum.GetValues(typeof(KeyboardKey));
 
             BeginInitImGui();
 
@@ -187,7 +187,7 @@ namespace rlImGui_cs
         {
             ImGuiIOPtr io = ImGui.GetIO();
 
-            foreach (var key in _keys) {
+            foreach (var key in Keys) {
                 io.KeysDown[(int)key] = Raylib.IsKeyDown(key);
             }
 


### PR DESCRIPTION
The old way caused a memory leak to occur where the Enum.GetValues was creating array each loop and the GC was not cleaning it up once finished. Plus I don't think there is a need to fetch it each loop as the enum is fixed on execution. 