### PR TITLE
Fix memory leak

### DIFF
--- a/rlImGui/rlImGui.cs
+++ b/rlImGui/rlImGui.cs
@@ -224,10 +224,9 @@ namespace rlImGui_cs
 
         private static void TriangleVert(ImDrawVertPtr idx_vert)
         {
-            byte[] c = BitConverter.GetBytes(idx_vert.col);
-
-            Rlgl.rlColor4ub(c[0], c[1], c[2], c[3]);
-
+            Vector4 color = ImGui.ColorConvertU32ToFloat4(idx_vert.col);
+            
+            Rlgl.rlColor4f(color.X, color.Y, color.Z, color.W);
             Rlgl.rlTexCoord2f(idx_vert.uv.X, idx_vert.uv.Y);
             Rlgl.rlVertex2f(idx_vert.pos.X, idx_vert.pos.Y);
         }


### PR DESCRIPTION
using `BitConverter.GetBytes` causes massive amounts of memory allocation. Using `ImGui.ColorConvertU32ToFloat4` seems to have completely removed the issue.