### PR TITLE
Fix clipboard crash and add extra methods

### DIFF
--- a/editor_example/ImageViewerWindow.cs
+++ b/editor_example/ImageViewerWindow.cs
@@ -17,6 +17,8 @@ namespace editor_example
         Vector2 LastTarget = new Vector2();
         bool Dragging = false;
 
+        Vector3 TintColor = new Vector3(1.0f, 1.0f, 1.0f);
+
         bool DirtyScene = false;
         enum ToolMode
         {
@@ -74,6 +76,14 @@ namespace editor_example
                     {
                         CurrentToolMode = ToolMode.Move;
                     }
+                    ImGui.SameLine();
+
+                    // temporarily reset window padding here so that the
+                    // color picker window doesn't look weird
+                    var windowPadding = ImGui.GetStyle().WindowPadding;
+                    ImGui.PopStyleVar();
+                    ImGui.ColorEdit3("Tint Color", ref TintColor, ImGuiColorEditFlags.NoInputs);
+                    ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, windowPadding);
 
                     ImGui.SameLine();
                     switch (CurrentToolMode)
@@ -89,11 +99,12 @@ namespace editor_example
                     }
 
                     ImGui.SameLine();
-                    ImGui.TextUnformatted(String.Format("camera target X%f Y%f", Camera.Target.X, Camera.Target.Y));
+                    ImGui.TextUnformatted(string.Format("camera target X{0} Y{1}", Camera.Target.X, Camera.Target.Y));
                     ImGui.EndChild();
                 }
 
-                rlImGui.ImageRect(ViewTexture.Texture, (int)size.X, (int)size.Y, viewRect);
+                var tintCol = new Color((int)(TintColor.X * 255) % 256, (int)(TintColor.Y * 255) % 256, (int)(TintColor.Z * 255) % 256, 255);
+                rlImGui.ImageRect(ViewTexture.Texture, (int)size.X, (int)size.Y, viewRect, tintCol);
 
                 ImGui.End();
             }

--- a/rlImGui/rlImGui.cs
+++ b/rlImGui/rlImGui.cs
@@ -24,7 +24,6 @@ namespace rlImGui_cs
     public static class rlImGui
     {
         internal static IntPtr ImGuiContext = IntPtr.Zero;
-        internal static nint iniFilenameAlloc = 0;
 
         private static ImGuiMouseCursor CurrentMouseCursor = ImGuiMouseCursor.COUNT;
         private static Dictionary<ImGuiMouseCursor, MouseCursor> MouseCursorMap = new Dictionary<ImGuiMouseCursor, MouseCursor>();
@@ -69,28 +68,6 @@ namespace rlImGui_cs
                 ImGui.GetIO().ConfigFlags |= ImGuiConfigFlags.DockingEnable;
 
             EndInitImGui();
-        }
-
-        /// <summary>
-        /// Set the filename of the INI file that ImGui uses to store the window configuration.
-        /// It is set to "imgui.ini" by default.
-        ///
-        /// Call this after rlImGui.Setup.
-        /// </summary>
-        /// <param name="iniFilename">The file path to store the ini file.</param>
-        public static void SetIniFilename(string iniFilename)
-        {
-            if (iniFilenameAlloc != 0)
-                Marshal.FreeHGlobal(iniFilenameAlloc);
-
-            byte[] nameBytes = System.Text.Encoding.ASCII.GetBytes(iniFilename + "\0");
-            iniFilenameAlloc = Marshal.AllocHGlobal(nameBytes.Length);
-            Marshal.Copy(nameBytes, 0, iniFilenameAlloc, nameBytes.Length);
-            
-            unsafe
-            {
-                ImGui.GetIO().NativePtr->IniFilename = (byte*) iniFilenameAlloc;
-            }
         }
 
         /// <summary>
@@ -672,9 +649,6 @@ namespace rlImGui_cs
 
                 IconFonts.FontAwesome6.IconFontRanges = IntPtr.Zero;
             }
-
-            if (iniFilenameAlloc != 0)
-                Marshal.FreeHGlobal(iniFilenameAlloc);
         }
 
         /// <summary>

--- a/rlImGui/rlImGui.cs
+++ b/rlImGui/rlImGui.cs
@@ -259,6 +259,9 @@ namespace rlImGui_cs
         private unsafe delegate sbyte* GetClipTextCallback(IntPtr userData);
         private unsafe delegate void SetClipTextCallback(IntPtr userData, sbyte* text);
 
+        private static GetClipTextCallback getClipCallback = null!;
+        private static SetClipTextCallback setClipCallback = null!;
+
         /// <summary>
         /// End Custom initialization. Not needed if you call Setup. Only needed if you want to add custom setup code.
         /// must be proceeded by BeginInitImGui
@@ -321,11 +324,11 @@ namespace rlImGui_cs
             // copy/paste callbacks
             unsafe
             {
-                GetClipTextCallback getClip = new GetClipTextCallback(rImGuiGetClipText);
-                SetClipTextCallback setClip = new SetClipTextCallback(rlImGuiSetClipText);
+                getClipCallback = new GetClipTextCallback(rImGuiGetClipText);
+                setClipCallback = new SetClipTextCallback(rlImGuiSetClipText);
 
-                io.SetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(setClip);
-                io.GetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(getClip);
+                io.SetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(setClipCallback);
+                io.GetClipboardTextFn = Marshal.GetFunctionPointerForDelegate(getClipCallback);
             }
 
             io.ClipboardUserData = IntPtr.Zero;


### PR DESCRIPTION
This pull request fixes a potential crash when ImGui interacts with the user's clipboard caused by the clipboard delegates being garbage-collected. It also adds extra methods that may be useful, namely one for setting the ini filename and several for drawing Image and ImageButtons with a tint and/or custom source UVs.